### PR TITLE
Reduce output html size and build time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@that-hatter/scrapi-factory": "^0.3.1",
-        "cross-env": "^7.0.3",
         "vitepress": "github:sr2ds/vitepress#package-json-script-prepare"
       },
       "devDependencies": {
@@ -1897,27 +1896,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2845,7 +2828,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3783,6 +3767,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4062,6 +4047,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4073,6 +4059,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4575,6 +4562,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,9 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@that-hatter/scrapi-factory": "^0.3.1",
-        "vitepress": "github:sr2ds/vitepress#package-json-script-prepare"
+        "vitepress": "^1.0.0-rc.32"
       },
       "devDependencies": {
-        "@types/node": "^20.10.4",
         "@typescript-eslint/eslint-plugin": "^5.26.0",
         "@typescript-eslint/parser": "^5.50.0",
         "@typescript-eslint/type-utils": "^5.50.0",
@@ -879,9 +878,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.0.tgz",
-      "integrity": "sha512-+1ge/xmaJpm1KVBuIH38Z94zj9fBD+hp+/5WLaHgyY8XLq1ibxk/zj6dTXaqM2cAbYKq8jYlhHd6k05If1W5xA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.1.tgz",
+      "integrity": "sha512-6vMdBZqtq1dVQ4CWdhFwhKZL6E4L1dV6jUjuBvsavvNJSppzi6dLBbuV+3+IyUREaj9ZFvQefnQm28v4OCXlig==",
       "cpu": [
         "arm"
       ],
@@ -891,9 +890,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.0.tgz",
-      "integrity": "sha512-im6hUEyQ7ZfoZdNvtwgEJvBWZYauC9KVKq1w58LG2Zfz6zMd8gRrbN+xCVoqA2hv/v6fm9lp5LFGJ3za8EQH3A==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.1.tgz",
+      "integrity": "sha512-Jto9Fl3YQ9OLsTDWtLFPtaIMSL2kwGyGoVCmPC8Gxvym9TCZm4Sie+cVeblPO66YZsYH8MhBKDMGZ2NDxuk/XQ==",
       "cpu": [
         "arm64"
       ],
@@ -903,9 +902,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.0.tgz",
-      "integrity": "sha512-u7aTMskN6Dmg1lCT0QJ+tINRt+ntUrvVkhbPfFz4bCwRZvjItx2nJtwJnJRlKMMaQCHRjrNqHRDYvE4mBm3DlQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.1.tgz",
+      "integrity": "sha512-LtYcLNM+bhsaKAIGwVkh5IOWhaZhjTfNOkGzGqdHvhiCUVuJDalvDxEdSnhFzAn+g23wgsycmZk1vbnaibZwwA==",
       "cpu": [
         "arm64"
       ],
@@ -915,9 +914,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.0.tgz",
-      "integrity": "sha512-8FvEl3w2ExmpcOmX5RJD0yqXcVSOqAJJUJ29Lca29Ik+3zPS1yFimr2fr5JSZ4Z5gt8/d7WqycpgkX9nocijSw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.1.tgz",
+      "integrity": "sha512-KyP/byeXu9V+etKO6Lw3E4tW4QdcnzDG/ake031mg42lob5tN+5qfr+lkcT/SGZaH2PdW4Z1NX9GHEkZ8xV7og==",
       "cpu": [
         "x64"
       ],
@@ -927,9 +926,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.0.tgz",
-      "integrity": "sha512-lHoKYaRwd4gge+IpqJHCY+8Vc3hhdJfU6ukFnnrJasEBUvVlydP8PuwndbWfGkdgSvZhHfSEw6urrlBj0TSSfg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.1.tgz",
+      "integrity": "sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==",
       "cpu": [
         "arm"
       ],
@@ -939,9 +938,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.0.tgz",
-      "integrity": "sha512-JbEPfhndYeWHfOSeh4DOFvNXrj7ls9S/2omijVsao+LBPTPayT1uKcK3dHW3MwDJ7KO11t9m2cVTqXnTKpeaiw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.1.tgz",
+      "integrity": "sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==",
       "cpu": [
         "arm64"
       ],
@@ -951,9 +950,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.0.tgz",
-      "integrity": "sha512-ahqcSXLlcV2XUBM3/f/C6cRoh7NxYA/W7Yzuv4bDU1YscTFw7ay4LmD7l6OS8EMhTNvcrWGkEettL1Bhjf+B+w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.1.tgz",
+      "integrity": "sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==",
       "cpu": [
         "arm64"
       ],
@@ -963,9 +962,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.0.tgz",
-      "integrity": "sha512-uwvOYNtLw8gVtrExKhdFsYHA/kotURUmZYlinH2VcQxNCQJeJXnkmWgw2hI9Xgzhgu7J9QvWiq9TtTVwWMDa+w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.1.tgz",
+      "integrity": "sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==",
       "cpu": [
         "riscv64"
       ],
@@ -975,9 +974,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.0.tgz",
-      "integrity": "sha512-m6pkSwcZZD2LCFHZX/zW2aLIISyzWLU3hrLLzQKMI12+OLEzgruTovAxY5sCZJkipklaZqPy/2bEEBNjp+Y7xg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.1.tgz",
+      "integrity": "sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==",
       "cpu": [
         "x64"
       ],
@@ -987,9 +986,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.0.tgz",
-      "integrity": "sha512-VFAC1RDRSbU3iOF98X42KaVicAfKf0m0OvIu8dbnqhTe26Kh6Ym9JrDulz7Hbk7/9zGc41JkV02g+p3BivOdAg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.1.tgz",
+      "integrity": "sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==",
       "cpu": [
         "x64"
       ],
@@ -999,9 +998,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.0.tgz",
-      "integrity": "sha512-9jPgMvTKXARz4inw6jezMLA2ihDBvgIU9Ml01hjdVpOcMKyxFBJrn83KVQINnbeqDv0+HdO1c09hgZ8N0s820Q==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.1.tgz",
+      "integrity": "sha512-7XI4ZCBN34cb+BH557FJPmh0kmNz2c25SCQeT9OiFWEgf8+dL6ZwJ8f9RnUIit+j01u07Yvrsuu1rZGxJCc51g==",
       "cpu": [
         "arm64"
       ],
@@ -1011,9 +1010,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.0.tgz",
-      "integrity": "sha512-WE4pT2kTXQN2bAv40Uog0AsV7/s9nT9HBWXAou8+++MBCnY51QS02KYtm6dQxxosKi1VIz/wZIrTQO5UP2EW+Q==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.1.tgz",
+      "integrity": "sha512-yE5c2j1lSWOH5jp+Q0qNL3Mdhr8WuqCNVjc6BxbVfS5cAS6zRmdiw7ktb8GNpDCEUJphILY6KACoFoRtKoqNQg==",
       "cpu": [
         "ia32"
       ],
@@ -1023,9 +1022,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.0.tgz",
-      "integrity": "sha512-aPP5Q5AqNGuT0tnuEkK/g4mnt3ZhheiXrDIiSVIHN9mcN21OyXDVbEMqmXPE7e2OplNLDkcvV+ZoGJa2ZImFgw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.1.tgz",
+      "integrity": "sha512-PyJsSsafjmIhVgaI1Zdj7m8BB8mMckFah/xbpplObyHfiXzKcI5UOUXRyOdHW7nz4DpMCuzLnF7v5IWHenCwYA==",
       "cpu": [
         "x64"
       ],
@@ -1110,7 +1109,8 @@
       "version": "20.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
       "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3953,9 +3953,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.0.tgz",
-      "integrity": "sha512-bUHW/9N21z64gw8s6tP4c88P382Bq/L5uZDowHlHx6s/QWpjJXivIAbEw6LZthgSvlEizZBfLC4OAvWe7aoF7A==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.1.tgz",
+      "integrity": "sha512-pgPO9DWzLoW/vIhlSoDByCzcpX92bKEorbgXuZrqxByte3JFk2xSW2JEeAcyLc9Ru9pqcNNW+Ob7ntsk2oT/Xw==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -3964,19 +3964,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.9.0",
-        "@rollup/rollup-android-arm64": "4.9.0",
-        "@rollup/rollup-darwin-arm64": "4.9.0",
-        "@rollup/rollup-darwin-x64": "4.9.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.9.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.9.0",
-        "@rollup/rollup-linux-arm64-musl": "4.9.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.9.0",
-        "@rollup/rollup-linux-x64-gnu": "4.9.0",
-        "@rollup/rollup-linux-x64-musl": "4.9.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.9.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.9.0",
-        "@rollup/rollup-win32-x64-msvc": "4.9.0",
+        "@rollup/rollup-android-arm-eabi": "4.9.1",
+        "@rollup/rollup-android-arm64": "4.9.1",
+        "@rollup/rollup-darwin-arm64": "4.9.1",
+        "@rollup/rollup-darwin-x64": "4.9.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.1",
+        "@rollup/rollup-linux-arm64-musl": "4.9.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.1",
+        "@rollup/rollup-linux-x64-gnu": "4.9.1",
+        "@rollup/rollup-linux-x64-musl": "4.9.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.1",
+        "@rollup/rollup-win32-x64-msvc": "4.9.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -4065,19 +4065,19 @@
       }
     },
     "node_modules/shikiji": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.7.6.tgz",
-      "integrity": "sha512-KzEtvSGQtBvfwVIB70kOmIfl/5rz1LC8j+tvlHXsJKAIdONNQvG1at7ivUUq3xUctqgO6fsO3AGomUSh0F+wsQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.2.tgz",
+      "integrity": "sha512-bxXd5iOVvuPj0NVFWQG3YMNLAGkWHyjTGixM7wLzqJNz3WMaeiOZbOP12gjQWKMJg+Ca4jmgATrUWu/rFb3B8A==",
       "dependencies": {
         "hast-util-to-html": "^9.0.0"
       }
     },
     "node_modules/shikiji-transformers": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.7.6.tgz",
-      "integrity": "sha512-yTp+7JMD/aXbV9ndn14eo9IK/UNt8iDsLNyqlOmCtcldlkqWE9T2YKAlOHOTVaeDfYWUWZa2EgSXb/CBfepBrw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.2.tgz",
+      "integrity": "sha512-WEBeNm+oUL/4OTENjnZ5G29ErNM2cPGJHRRhqjwoTFkHnsJsACtTluTaYjPEppCl46Vo3M4TV9GwrMxz2WeCSg==",
       "dependencies": {
-        "shikiji": "0.7.6"
+        "shikiji": "0.9.2"
       }
     },
     "node_modules/slash": {
@@ -4287,7 +4287,8 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/unist-util-is": {
       "version": "6.0.0",
@@ -4479,32 +4480,32 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.0.0-rc.31",
-      "resolved": "git+ssh://git@github.com/sr2ds/vitepress.git#94e3ec6baac8443b4caacf19d44327449ccc7ac6",
-      "license": "MIT",
+      "version": "1.0.0-rc.32",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.32.tgz",
+      "integrity": "sha512-yf00Skn5BGP+YOQvTbSrB5s9qEb/cV+i+wM5rw+mlaxcIYtK+ORvyBEYZLvKogs7OO70TppJtixb4ofeo5K7HA==",
       "dependencies": {
         "@docsearch/css": "^3.5.2",
         "@docsearch/js": "^3.5.2",
         "@types/markdown-it": "^13.0.7",
-        "@vitejs/plugin-vue": "^4.5.0",
+        "@vitejs/plugin-vue": "^4.5.2",
         "@vue/devtools-api": "^6.5.1",
-        "@vueuse/core": "^10.6.1",
-        "@vueuse/integrations": "^10.6.1",
+        "@vueuse/core": "^10.7.0",
+        "@vueuse/integrations": "^10.7.0",
         "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
         "minisearch": "^6.3.0",
         "mrmime": "^1.0.1",
-        "shikiji": "^0.7.4",
-        "shikiji-transformers": "^0.7.4",
-        "vite": "^5.0.2",
-        "vue": "^3.3.8"
+        "shikiji": "0.9.2",
+        "shikiji-transformers": "0.9.2",
+        "vite": "^5.0.10",
+        "vue": "^3.3.11"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
       },
       "peerDependencies": {
         "markdown-it-mathjax3": "^4.3.2",
-        "postcss": "^8.4.31"
+        "postcss": "^8.4.32"
       },
       "peerDependenciesMeta": {
         "markdown-it-mathjax3": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "author": "that-hatter",
   "license": "AGPL-3.0-or-later",
   "devDependencies": {
-    "@types/node": "^20.10.4",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^5.50.0",
     "@typescript-eslint/type-utils": "^5.50.0",
@@ -39,6 +38,6 @@
   },
   "dependencies": {
     "@that-hatter/scrapi-factory": "^0.3.1",
-    "vitepress": "github:sr2ds/vitepress#package-json-script-prepare"
+    "vitepress": "^1.0.0-rc.32"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "create-api-pages": "npx tsc && node dist/book",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "cross-env NODE_OPTIONS=--max-old-space-size=6144 vitepress build docs",
+    "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },
   "keywords": [
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@that-hatter/scrapi-factory": "^0.3.1",
-    "cross-env": "^7.0.3",
     "vitepress": "github:sr2ds/vitepress#package-json-script-prepare"
   }
 }

--- a/src/apiPage/Constant.ts
+++ b/src/apiPage/Constant.ts
@@ -188,27 +188,3 @@ export const page =
       O.getOrElse(() => enumNotFoundError(ct))
     );
   };
-
-export const sidebarGroup = (api: sf.API) => ({
-  text: 'Constants',
-  collapsed: true,
-  items: pipe(
-    api.enums.array,
-    RA.map((en) =>
-      pipe(
-        api.constants.array,
-        RA.filter((c) => c.enum === en.name),
-        RA.map((c) => ({
-          text: c.partialName,
-          link: Topic.url(c),
-        })),
-        (items) => ({
-          text: en.name,
-          link: Topic.url(en),
-          collapsed: true,
-          items,
-        })
-      )
-    )
-  ),
-});

--- a/src/apiPage/Enum.ts
+++ b/src/apiPage/Enum.ts
@@ -20,3 +20,15 @@ export const page =
       PageInfo.seeAlsoSection(en),
       Topic.tagsSection(en)(api),
     ]);
+
+export const sidebarGroup = (api: sf.API) => ({
+  text: 'Constants',
+  collapsed: true,
+  items: pipe(
+    api.enums.array,
+    RA.map((en) => ({
+      text: en.name,
+      link: Topic.url(en),
+    }))
+  ),
+});

--- a/src/apiPage/Function.ts
+++ b/src/apiPage/Function.ts
@@ -96,32 +96,3 @@ export const page =
       Topic.tagsSection(fn)(api),
     ]);
   };
-
-export const sidebarGroup = (api: sf.API) => ({
-  text: 'Functions',
-  collapsed: true,
-  items: pipe(
-    api.namespaces.array,
-    RA.filter((ns) => !Topic.isAliasCopy(ns)),
-    RA.map((ns) =>
-      pipe(
-        api.functions.array,
-        RA.filter((f) =>
-          O.isSome(f.namespace)
-            ? ns.name === f.namespace.value
-            : ns.name === '(Global)'
-        ),
-        RA.map((f) => ({
-          text: f.partialName,
-          link: Topic.url(f),
-        })),
-        (items) => ({
-          text: ns.name,
-          link: Topic.url(ns),
-          collapsed: true,
-          items,
-        })
-      )
-    )
-  ),
-});

--- a/src/apiPage/Namespace.ts
+++ b/src/apiPage/Namespace.ts
@@ -37,7 +37,6 @@ export const page =
       DescInfo.descAndGuide(nm),
       Topic.aliasesSection(api.namespaces.record)(nm),
       membersSummaryList(nm, 2, 'Functions', api.functions.array),
-      membersSummaryList(nm, 2, 'Constants', api.constants.array),
       TopicInfo.seeAlsoSection(nm),
       Topic.tagsSection(nm)(api),
     ]);

--- a/src/apiPage/Namespace.ts
+++ b/src/apiPage/Namespace.ts
@@ -42,3 +42,16 @@ export const page =
       Topic.tagsSection(nm)(api),
     ]);
   };
+
+export const sidebarGroup = (api: sf.API) => ({
+  text: 'Functions',
+  collapsed: true,
+  items: pipe(
+    api.namespaces.array,
+    RA.filter((ns) => !Topic.isAliasCopy(ns)),
+    RA.map((ns) => ({
+      text: ns.name,
+      link: Topic.url(ns),
+    }))
+  ),
+});

--- a/src/apiPage/Tag.ts
+++ b/src/apiPage/Tag.ts
@@ -1,5 +1,5 @@
 import type * as sf from '@that-hatter/scrapi-factory';
-import { O, RA, pipe } from '@that-hatter/scrapi-factory/fp';
+import { O, RA, flow, pipe } from '@that-hatter/scrapi-factory/fp';
 import * as md from '@that-hatter/scrapi-factory/markdown';
 import * as DescInfo from './shared/DescInfo';
 import * as Topic from './shared/Topic';
@@ -39,3 +39,9 @@ export const sidebarGroup = (api: sf.API) => ({
     RA.map((t) => ({ text: t.name, link: Topic.url(t) }))
   ),
 });
+
+export const indexPage = flow(
+  Topic.summaryListWithHeading(1, 'Tags'),
+  RA.of,
+  md.combinedFragments
+);

--- a/src/apiPage/Tag.ts
+++ b/src/apiPage/Tag.ts
@@ -31,15 +31,6 @@ export const page =
     ]);
   };
 
-export const sidebarGroup = (api: sf.API) => ({
-  text: 'Tags',
-  collapsed: true,
-  items: pipe(
-    api.tags.array,
-    RA.map((t) => ({ text: t.name, link: Topic.url(t) }))
-  ),
-});
-
 export const indexPage = flow(
   Topic.summaryListWithHeading(1, 'Tags'),
   RA.of,

--- a/src/apiPage/Type.ts
+++ b/src/apiPage/Type.ts
@@ -180,6 +180,10 @@ const getTableTypes = memoize((_: ReadonlyArray<sf.Type>) => 'tables')(
   RA.filter(isTableType)
 );
 
+const getOtherTypes = memoize((_: ReadonlyArray<sf.Type>) => 'others')(
+  RA.filter((t) => typeof t.supertype !== 'symbol')
+);
+
 export const page =
   (tp: sf.Type) =>
   (api: sf.API): md.Root => {
@@ -260,3 +264,10 @@ export const sidebarGroup = ({ types }: sf.API) => {
     ],
   };
 };
+
+export const indexPage = (docs: ReadonlyArray<sf.Type>) =>
+  md.combinedFragments([
+    Topic.summaryListWithHeading(1, 'Types')(getOtherTypes(docs)),
+    Topic.summaryListWithHeading(2, 'Function Types')(getFunctionTypes(docs)),
+    Topic.summaryListWithHeading(2, 'Table Types')(getTableTypes(docs)),
+  ]);

--- a/src/apiPage/Type.ts
+++ b/src/apiPage/Type.ts
@@ -9,7 +9,6 @@ import {
   pipe,
 } from '@that-hatter/scrapi-factory/fp';
 import * as md from '@that-hatter/scrapi-factory/markdown';
-import { Predicate } from 'fp-ts/Predicate';
 import * as Rd from 'fp-ts/Reader';
 import * as Comp from './shared/Component';
 import * as SignatureInfo from './shared/SignatureInfo';
@@ -235,34 +234,9 @@ export const page =
     ]);
   };
 
-const sidebarSubgroup = (
-  types: ReadonlyArray<sf.Type>,
-  text: string,
-  pred: Predicate<sf.Type>
-) => ({
-  text,
-  collapsed: true,
-  items: pipe(
-    types,
-    RA.filter(pred),
-    RA.map((tp) => ({ text: tp.name, link: Topic.url(tp) }))
-  ),
-});
-
-export const sidebarGroup = ({ types }: sf.API) => {
-  const sidebar = sidebarSubgroup(
-    types.array,
-    'Types',
-    (tp) => typeof tp.supertype !== 'symbol'
-  );
-  return {
-    ...sidebar,
-    items: [
-      ...sidebar.items,
-      sidebarSubgroup(types.array, 'Function Types', isFunctionType),
-      sidebarSubgroup(types.array, 'Table Types', isTableType),
-    ],
-  };
+export const sidebarGroup = {
+  text: 'Types',
+  link: '/api/types/__index',
 };
 
 export const indexPage = (docs: ReadonlyArray<sf.Type>) =>

--- a/src/book.ts
+++ b/src/book.ts
@@ -55,8 +55,14 @@ const generateAPIPages = <T extends sf.Topic>(
 const createSidebar = (api: sf.API) => [
   Namespace.sidebarGroup(api),
   Enum.sidebarGroup(api),
-  Type.sidebarGroup(api),
-  Tag.sidebarGroup(api),
+  {
+    text: 'Types',
+    link: '/api/types/__index',
+  },
+  {
+    text: 'Tags',
+    link: '/api/tags/__index',
+  },
 ];
 
 const generateSidebarFile = (api: sf.API) =>

--- a/src/book.ts
+++ b/src/book.ts
@@ -17,7 +17,7 @@ type APIPage<T extends sf.Topic> = {
   readonly link: string;
 };
 
-const prepareAll = <T extends sf.Topic>(
+const prepareAPIPages = <T extends sf.Topic>(
   pageFn: (t: T) => R.Reader<sf.API, md.Root>
 ) =>
   flow(
@@ -62,18 +62,32 @@ const generateSidebarFile = (api: sf.API) =>
     JSON.stringify(createSidebar(api), null, 2)
   );
 
+const generateTypesIndexFile = (api: sf.API) =>
+  writeFileTask(
+    path.join(process.cwd(), 'docs', 'api', 'types', '__index.md'),
+    md.compile(Type.indexPage(api.types.array))
+  );
+
+const generateTagsIndexFile = (api: sf.API) =>
+  writeFileTask(
+    path.join(process.cwd(), 'docs', 'api', 'tags', '__index.md'),
+    md.compile(Tag.indexPage(api.tags.array))
+  );
+
 const generateFiles = (api: sf.API) =>
   pipe(
     [
-      ...prepareAll(Constant.page)(api.constants.array)(api),
-      ...prepareAll(Enum.page)(api.enums.array)(api),
-      ...prepareAll(Function.page)(api.functions.array)(api),
-      ...prepareAll(Namespace.page)(api.namespaces.array)(api),
-      ...prepareAll(Tag.page)(api.tags.array)(api),
-      ...prepareAll(Type.page)(api.types.array)(api),
+      ...prepareAPIPages(Constant.page)(api.constants.array)(api),
+      ...prepareAPIPages(Enum.page)(api.enums.array)(api),
+      ...prepareAPIPages(Function.page)(api.functions.array)(api),
+      ...prepareAPIPages(Namespace.page)(api.namespaces.array)(api),
+      ...prepareAPIPages(Tag.page)(api.tags.array)(api),
+      ...prepareAPIPages(Type.page)(api.types.array)(api),
     ],
     RA.map(generatePageFile),
     RA.append(generateSidebarFile(api)),
+    RA.append(generateTypesIndexFile(api)),
+    RA.append(generateTagsIndexFile(api)),
     TE.sequenceArray
   );
 

--- a/src/book.ts
+++ b/src/book.ts
@@ -36,8 +36,8 @@ const prepareAll = <T extends sf.Topic>(
   );
 
 const createSidebar = (api: sf.API) => [
-  Function.sidebarGroup(api),
-  Constant.sidebarGroup(api),
+  Namespace.sidebarGroup(api),
+  Enum.sidebarGroup(api),
   Type.sidebarGroup(api),
   Tag.sidebarGroup(api),
 ];


### PR DESCRIPTION
- remove the links to every doc entry in the sidebar
- create index pages for tags and types
- remove memory workarounds used to generate earlier version